### PR TITLE
Run hostnamectl without --transient

### DIFF
--- a/lib/kitchen/driver/qemu.rb
+++ b/lib/kitchen/driver/qemu.rb
@@ -292,7 +292,7 @@ module Kitchen
         conn.execute(<<-EOS)
 sudo sh -s 2>/dev/null <<END
 echo '127.0.0.1 #{names}' >> /etc/hosts
-hostnamectl --transient set-hostname #{hostname} || hostname #{hostname}
+hostnamectl set-hostname #{hostname} || hostname #{hostname}
 END
 umask 0022
 install -dm700 "$HOME/.ssh"

--- a/lib/kitchen/driver/qemu_version.rb
+++ b/lib/kitchen/driver/qemu_version.rb
@@ -17,6 +17,6 @@
 module Kitchen
   module Driver
     # Version string for the QEMU Kitchen driver
-    QEMU_VERSION = '0.2.8.dev'
+    QEMU_VERSION = '0.2.9.dev'
   end
 end


### PR DESCRIPTION
uname -a wont read the transient hostname if the static is set