### PR TITLE
Removed "default" option from -mon 

### DIFF
--- a/lib/kitchen/driver/qemu.rb
+++ b/lib/kitchen/driver/qemu.rb
@@ -179,7 +179,7 @@ module Kitchen
           config[:binary], '-daemonize',
           '-display', config[:display].to_s,
           '-chardev', "socket,id=mon-qmp,path=#{monitor},server,nowait",
-          '-mon', 'chardev=mon-qmp,mode=control,default',
+          '-mon', 'chardev=mon-qmp,mode=control',
           '-serial', "mon:unix:path=#{serial_path},server,nowait",
           '-m', config[:memory].to_s,
         ]


### PR DESCRIPTION
The default option for -mon is no longer present in qemu 2.12. I have tested this change with qemu 2.11 as well.
https://qemu.weilnetz.de/doc/qemu-doc.html#index-_002dmon 