### PR TITLE
Enable OSX users to use hypervisor.framework

### DIFF
--- a/lib/kitchen/driver/qemu.rb
+++ b/lib/kitchen/driver/qemu.rb
@@ -41,6 +41,7 @@ module Kitchen
       default_config :port_max,   65535
       default_config :display,    'none'
       default_config :memory,     '512'
+      default_config :hvf,        false
       default_config :hostshares, []
       default_config :args,       []
 
@@ -199,6 +200,9 @@ module Kitchen
         if kvm
           info 'KVM enabled.'
           cmd.push('-enable-kvm', '-cpu', 'host')
+        elsif config[:hvf]
+          cmd.push('-cpu', 'host', '-M', 'accel=hvf')
+          info 'hypervisor.framework enabled.'
         else
           info 'KVM disabled'
         end


### PR DESCRIPTION
This requires one to [patch qemu](http://www.breakintheweb.com/2017/10/14/Qemu-on-MacOSX-with-Hypervisor-Framework/), but it does make it usable on
OSX. In order to use hvf with this commit simply add `hvf: true` to the
driver config.
