### PR TITLE
Update dependency to work with test-kitchen 2.0+

### DIFF
--- a/kitchen-qemu.gemspec
+++ b/kitchen-qemu.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |gem|
   gem.executables   = []
   gem.require_paths = [ 'lib' ]
 
-  gem.add_dependency 'test-kitchen', '~> 1.4'
+  gem.add_dependency 'test-kitchen', '~> 2.0'
 end

--- a/lib/kitchen/driver/qemu_version.rb
+++ b/lib/kitchen/driver/qemu_version.rb
@@ -17,6 +17,6 @@
 module Kitchen
   module Driver
     # Version string for the QEMU Kitchen driver
-    QEMU_VERSION = '0.2.9.dev'
+    QEMU_VERSION = '0.2.11'
   end
 end


### PR DESCRIPTION
I wasn't sure if the driver version needed to be bumped, but figured it made sense. 

I've run the code using test-kitchen 2.2.5 against several Chef cookbooks that utilize kitchen tests and it hasn't given any errors and works as before with the older test-kitchen. Not sure how else to test it. 